### PR TITLE
fix(Readme): typo on docker command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,21 +1,24 @@
 # Getting Started
+
 This is a docker-compose file to setup a local mongodb instance.
 
-### Recommend  
- - Its very recommended to have [MongoDB Compass](https://www.mongodb.com/try/download/compass) installed its a great tool provided by the MongoDB team
+### Recommend
+
+- Its very recommended to have [MongoDB Compass](https://www.mongodb.com/try/download/compass) installed its a great tool provided by the MongoDB team
 
 ### Must haves
- - Docker and Docker-Compose installed follow this guide
-   - [Linux](https://docs.docker.com/desktop/install/linux-install/)
-   - [Mac](https://docs.docker.com/desktop/install/mac-install/)
-   - [Windows](https://docs.docker.com/desktop/install/windows-install/)
+
+- Docker and Docker-Compose installed follow this guide
+  - [Linux](https://docs.docker.com/desktop/install/linux-install/)
+  - [Mac](https://docs.docker.com/desktop/install/mac-install/)
+  - [Windows](https://docs.docker.com/desktop/install/windows-install/)
 
 ## Lets get Started
 
 enter this command in the root directory of the project
 
 ```bash
-docker compose up -d
+docker-compose up -d
 ```
 
 once completed you should enter this command next


### PR DESCRIPTION
fix in Readme file for a  typo on docker command. 

`docker compose` --> `docker-compose`

Morever, minor linting fixes for Readme